### PR TITLE
deps: control grpc version + only rely on grpc-api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,11 @@ inThisBuild(
     organization := "org.lyranthe.fs2-grpc",
     git.useGitDescribe := true,
     scmInfo := Some(ScmInfo(url("https://github.com/fiadliel/fs2-grpc"), "git@github.com:fiadliel/fs2-grpc.git"))
-  ))
+  )
+)
 
-lazy val root = project.in(file("."))
+lazy val root = project
+  .in(file("."))
   .enablePlugins(GitVersioning, BuildInfoPlugin)
   .settings(
     sonatypeProfileName := "org.lyranthe",
@@ -50,7 +52,7 @@ lazy val `java-runtime` = project
     scalaVersion := "2.13.1",
     crossScalaVersions := List(scalaVersion.value, "2.12.10"),
     publishTo := sonatypePublishToBundle.value,
-    libraryDependencies ++= List(fs2, catsEffect, grpcCore) ++ List(grpcNetty, catsEffectLaws, minitest).map(_  % Test),
+    libraryDependencies ++= List(fs2, catsEffect, grpcApi) ++ List(grpcNetty, catsEffectLaws, minitest).map(_ % Test),
     mimaPreviousArtifacts := Set(organization.value %% name.value % "0.3.0"),
     Test / parallelExecution := false,
     testFrameworks += new TestFramework("minitest.runner.Framework"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object versions {
 
-    val grpc = scalapb.compiler.Version.grpcJavaVersion
+    val grpc = "1.28.0"
     val scalaPb = scalapb.compiler.Version.scalapbVersion
     val fs2 = "2.2.2"
     val catsEffect = "2.1.2"
@@ -19,7 +19,7 @@ object Dependencies {
 
   val fs2 = "co.fs2" %% "fs2-core" % versions.fs2
   val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
-  val grpcCore = "io.grpc" % "grpc-core" % versions.grpc
+  val grpcApi = "io.grpc" % "grpc-api" % versions.grpc
 
   // Testing
 


### PR DESCRIPTION
 - make grpc version explicit instead of relying on
   what scalapb brings about.

 - change dependency on grpc for runtime to only rely
   on grpc-api as grpc-core is not needed.